### PR TITLE
Bugfix to storing incorrect playlist: videoId is being stored instead…

### DIFF
--- a/client/src/Features/Playlist/PlaylistSlice.js
+++ b/client/src/Features/Playlist/PlaylistSlice.js
@@ -25,7 +25,7 @@ const initialState = {
 const addMusicToPlaylistReducer = function (state, action) {
     const videoId = action.payload;
     state.playlist.includes(videoId) ? state = {...state.playlist, alert: false} : state.playlist.push(videoId)
-    localStorage.setItem('playlist', JSON.stringify(videoId));
+    localStorage.setItem('playlist', JSON.stringify(state.playlist));
 }
 
 /**


### PR DESCRIPTION
… of the playlist

What being stored in the cache was not the playlist, but was the videoId. It returns an error and