### PR TITLE
Update YoutubeHandler.js

### DIFF
--- a/server/src/youtube/YoutubeHandler.js
+++ b/server/src/youtube/YoutubeHandler.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var youtube;
 
 // ============== Global Variables ==================
-var keyLoc = "./.config/API_KEY";
+var keyLoc = "./config/API_KEY";
 var API_KEY;
 
 // ================= Methods ========================


### PR DESCRIPTION
Remove the dot prefix on config folder as fs cannot access a hidden folder in linux (Note that folders with dot prefix are considered hidden and private in LINUX. Since heroku is running in a linux environment, it cannot access .config folder)